### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm publish -r --access public
+          publish: pnpm _ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "mod:build": "turbo run --no-daemon @vintl/nuxt#build",
     "mod:lint": "turbo run --no-daemon @vintl/nuxt#lint",
     "all:prepare": "turbo run --no-daemon prepare",
-    "all:lint": "turbo run --no-daemon lint"
+    "all:lint": "turbo run --no-daemon lint",
+    "_ci:publish": "changeset publish"
   },
   "pnpm": {
     "patchedDependencies": {


### PR DESCRIPTION
Release workflow did not use `changeset publish`, which broke the GitHub releases and tags. Whoops.