### PR TITLE
Explicitly pass build subcommand to nuxt-module-build

### DIFF
--- a/.changeset/lovely-doors-heal.md
+++ b/.changeset/lovely-doors-heal.md
@@ -1,0 +1,7 @@
+---
+'@vintl/nuxt': minor
+---
+
+Add support for parsing the messages in the error handlers
+
+With [update to `@vintl/unplugin`](https://github.com/vintl-dev/unplugin/releases/tag/v1.5.0), it's now possible to use `parseMessage` from the error handler's context to parse custom messages or re-parse the current message with any modified options.

--- a/packages/vintl-nuxt/package.json
+++ b/packages/vintl-nuxt/package.json
@@ -54,7 +54,7 @@
     "@formatjs/intl": "^2.9.3",
     "@formatjs/intl-localematcher": "^0.4.2",
     "@nuxt/kit": "^3.7.4",
-    "@vintl/unplugin": "^1.4.1",
+    "@vintl/unplugin": "^1.5.0",
     "@vintl/vintl": "^4.2.3",
     "astring": "^1.8.6",
     "consola": "^3.2.3",

--- a/packages/vintl-nuxt/package.json
+++ b/packages/vintl-nuxt/package.json
@@ -34,7 +34,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "nuxt-module-build",
+    "build": "nuxt-module-build build",
     "lint": "eslint --cache .",
     "prepack": "pnpm run -s lint && pnpm run -s build"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,7 +69,7 @@ importers:
         version: 3.9.0
       nuxt:
         specifier: ^3.7.4
-        version: 3.7.4(eslint@8.51.0)
+        version: 3.7.4(eslint@8.51.0)(rollup@3.23.0)(typescript@5.2.2)
 
   packages/eslint-config:
     dependencies:
@@ -110,8 +110,8 @@ importers:
         specifier: ^3.7.4
         version: 3.7.4(rollup@3.29.4)
       '@vintl/unplugin':
-        specifier: ^1.4.1
-        version: 1.4.1(rollup@3.29.4)(vue@3.3.4)(webpack@5.83.1)
+        specifier: ^1.5.0
+        version: 1.5.0(rollup@3.29.4)(vue@3.3.4)(webpack@5.83.1)
       '@vintl/vintl':
         specifier: ^4.2.3
         version: 4.2.3(typescript@5.2.2)(vue@3.3.4)
@@ -1979,38 +1979,6 @@ packages:
       - supports-color
     dev: true
 
-  /@nuxt/kit@3.7.4(esbuild@0.19.4):
-    resolution: {integrity: sha512-/S5abZL62BITCvC/TY3KWA6N721U1Osln3cQdBb56XHIeafZCBVqTi92Xb0o7ovl72mMRhrKwRu7elzvz9oT/g==}
-    engines: {node: ^14.18.0 || >=16.10.0}
-    dependencies:
-      '@nuxt/schema': 3.7.4
-      c12: 1.4.2
-      consola: 3.2.3
-      defu: 6.1.2
-      globby: 13.2.2
-      hash-sum: 2.0.0
-      ignore: 5.2.4
-      jiti: 1.20.0
-      knitwork: 1.0.0
-      mlly: 1.4.2
-      pathe: 1.1.1
-      pkg-types: 1.0.3
-      scule: 1.0.0
-      semver: 7.5.4
-      ufo: 1.3.1
-      unctx: 2.3.1
-      unimport: 3.4.0
-      untyped: 1.4.0
-      webpack: 5.83.1(esbuild@0.19.4)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - rollup
-      - supports-color
-      - uglify-js
-      - webpack-cli
-    dev: true
-
   /@nuxt/kit@3.7.4(esbuild@0.19.4)(rollup@3.23.0):
     resolution: {integrity: sha512-/S5abZL62BITCvC/TY3KWA6N721U1Osln3cQdBb56XHIeafZCBVqTi92Xb0o7ovl72mMRhrKwRu7elzvz9oT/g==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -2126,26 +2094,6 @@ packages:
       - typescript
     dev: true
 
-  /@nuxt/schema@3.7.4:
-    resolution: {integrity: sha512-q6js+97vDha4Fa2x2kDVEuokJr+CGIh1TY2wZp2PLZ7NhG3XEeib7x9Hq8XE8B6pD0GKBRy3eRPPOY69gekBCw==}
-    engines: {node: ^14.18.0 || >=16.10.0}
-    dependencies:
-      '@nuxt/ui-templates': 1.3.1
-      consola: 3.2.3
-      defu: 6.1.2
-      hookable: 5.5.3
-      pathe: 1.1.1
-      pkg-types: 1.0.3
-      postcss-import-resolver: 2.0.0
-      std-env: 3.4.3
-      ufo: 1.3.1
-      unimport: 3.4.0
-      untyped: 1.4.0
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-    dev: true
-
   /@nuxt/schema@3.7.4(rollup@3.23.0):
     resolution: {integrity: sha512-q6js+97vDha4Fa2x2kDVEuokJr+CGIh1TY2wZp2PLZ7NhG3XEeib7x9Hq8XE8B6pD0GKBRy3eRPPOY69gekBCw==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -2184,36 +2132,6 @@ packages:
     transitivePeerDependencies:
       - rollup
       - supports-color
-
-  /@nuxt/telemetry@2.5.2(esbuild@0.19.4):
-    resolution: {integrity: sha512-kZ+rWq/5MZonMhp8KGFI5zMaR2VsiWpnlkOLJIuIX2WoJl0DkHvtxCtuFq2erAqMVruWLpKU+tgMC+1cno/QmA==}
-    hasBin: true
-    dependencies:
-      '@nuxt/kit': 3.7.4(esbuild@0.19.4)
-      ci-info: 3.8.0
-      consola: 3.2.3
-      create-require: 1.1.1
-      defu: 6.1.2
-      destr: 2.0.1
-      dotenv: 16.3.1
-      git-url-parse: 13.1.0
-      is-docker: 3.0.0
-      jiti: 1.20.0
-      mri: 1.2.0
-      nanoid: 4.0.2
-      ofetch: 1.3.3
-      parse-git-config: 3.0.0
-      pathe: 1.1.1
-      rc9: 2.1.1
-      std-env: 3.4.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - rollup
-      - supports-color
-      - uglify-js
-      - webpack-cli
-    dev: true
 
   /@nuxt/telemetry@2.5.2(esbuild@0.19.4)(rollup@3.23.0):
     resolution: {integrity: sha512-kZ+rWq/5MZonMhp8KGFI5zMaR2VsiWpnlkOLJIuIX2WoJl0DkHvtxCtuFq2erAqMVruWLpKU+tgMC+1cno/QmA==}
@@ -2256,71 +2174,6 @@ packages:
     dependencies:
       '@nuxt/kit': 3.7.4(esbuild@0.19.4)(rollup@3.23.0)
       '@rollup/plugin-replace': 5.0.2(rollup@3.23.0)
-      '@vitejs/plugin-vue': 4.4.0(vite@4.4.11)(vue@3.3.4)
-      '@vitejs/plugin-vue-jsx': 3.0.2(vite@4.4.11)(vue@3.3.4)
-      autoprefixer: 10.4.16(postcss@8.4.31)
-      clear: 0.1.0
-      consola: 3.2.3
-      cssnano: 6.0.1(postcss@8.4.31)
-      defu: 6.1.2
-      esbuild: 0.19.4
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      externality: 1.0.2
-      fs-extra: 11.1.1
-      get-port-please: 3.1.1
-      h3: 1.8.2
-      knitwork: 1.0.0
-      magic-string: 0.30.4
-      mlly: 1.4.2
-      ohash: 1.1.3
-      pathe: 1.1.1
-      perfect-debounce: 1.0.0
-      pkg-types: 1.0.3
-      postcss: 8.4.31
-      postcss-import: 15.1.0(postcss@8.4.31)
-      postcss-url: 10.1.3(postcss@8.4.31)
-      rollup-plugin-visualizer: 5.9.2(rollup@3.23.0)
-      std-env: 3.4.3
-      strip-literal: 1.3.0
-      ufo: 1.3.1
-      unplugin: 1.5.0
-      vite: 4.4.11
-      vite-node: 0.33.0
-      vite-plugin-checker: 0.6.2(eslint@8.51.0)(typescript@5.2.2)(vite@4.4.11)
-      vue: 3.3.4
-      vue-bundle-renderer: 2.0.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@types/node'
-      - eslint
-      - less
-      - lightningcss
-      - meow
-      - optionator
-      - rollup
-      - sass
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - typescript
-      - uglify-js
-      - vls
-      - vti
-      - vue-tsc
-      - webpack-cli
-    dev: true
-
-  /@nuxt/vite-builder@3.7.4(eslint@8.51.0)(vue@3.3.4):
-    resolution: {integrity: sha512-EWZlUzYvkSfIZPA0pQoi7P++68Mlvf5s/G3GBPksS5JB/9l3yZTX+ZqGvLeORSBmoEpJ6E2oMn2WvCHV0W5y6Q==}
-    engines: {node: ^14.18.0 || >=16.10.0}
-    peerDependencies:
-      vue: ^3.3.4
-    dependencies:
-      '@nuxt/kit': 3.7.4(esbuild@0.19.4)
-      '@rollup/plugin-replace': 5.0.2
       '@vitejs/plugin-vue': 4.4.0(vite@4.4.11)(vue@3.3.4)
       '@vitejs/plugin-vue-jsx': 3.0.2(vite@4.4.11)(vue@3.3.4)
       autoprefixer: 10.4.16(postcss@8.4.31)
@@ -2741,19 +2594,6 @@ packages:
       is-module: 1.0.0
       resolve: 1.22.2
       rollup: 3.29.4
-    dev: true
-
-  /@rollup/plugin-replace@5.0.2:
-    resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.0.5(rollup@3.29.4)
-      magic-string: 0.27.0
     dev: true
 
   /@rollup/plugin-replace@5.0.2(rollup@3.23.0):
@@ -3187,8 +3027,8 @@ packages:
       - supports-color
     dev: true
 
-  /@vintl/unplugin@1.4.1(rollup@3.29.4)(vue@3.3.4)(webpack@5.83.1):
-    resolution: {integrity: sha512-Fax4nGTLQQrS4rs/ZSP3BsBt2aW12H0rgYo/MAj4XbY03ZzNR5iBSWM1yGNHP3xCn+tpVtUU9Bpd+n8q3/rg5A==}
+  /@vintl/unplugin@1.5.0(rollup@3.29.4)(vue@3.3.4)(webpack@5.83.1):
+    resolution: {integrity: sha512-RFpbBho4cfLSikgM3YvrJXjnWlwBJISvplc1j8bDjD7Mmp7DfKb7v3ZmOpD7M3cdZ3v38DcPQ/ig7wqTN44LQg==}
     engines: {node: '>=16'}
     peerDependencies:
       rollup: ^3
@@ -3298,26 +3138,6 @@ packages:
       '@rollup/pluginutils': 5.0.5(rollup@3.23.0)
       '@vue/compiler-sfc': 3.3.4
       ast-kit: 0.11.2(rollup@3.23.0)
-      local-pkg: 0.4.3
-      magic-string-ast: 0.3.0
-      vue: 3.3.4
-    transitivePeerDependencies:
-      - rollup
-    dev: true
-
-  /@vue-macros/common@1.8.0(vue@3.3.4):
-    resolution: {integrity: sha512-auDJJzE0z3uRe3867e0DsqcseKImktNf5ojCZgUKqiVxb2yTlwlgOVAYCgoep9oITqxkXQymSvFeKhedi8PhaA==}
-    engines: {node: '>=16.14.0'}
-    peerDependencies:
-      vue: ^2.7.0 || ^3.2.25
-    peerDependenciesMeta:
-      vue:
-        optional: true
-    dependencies:
-      '@babel/types': 7.23.0
-      '@rollup/pluginutils': 5.0.5(rollup@3.29.4)
-      '@vue/compiler-sfc': 3.3.4
-      ast-kit: 0.11.2
       local-pkg: 0.4.3
       magic-string-ast: 0.3.0
       vue: 3.3.4
@@ -3838,34 +3658,12 @@ packages:
       util: 0.12.5
     dev: true
 
-  /ast-kit@0.11.2:
-    resolution: {integrity: sha512-Q0DjXK4ApbVoIf9GLyCo252tUH44iTnD/hiJ2TQaJeydYWSpKk0sI34+WMel8S9Wt5pbLgG02oJ+gkgX5DV3sQ==}
-    engines: {node: '>=16.14.0'}
-    dependencies:
-      '@babel/parser': 7.23.0
-      '@rollup/pluginutils': 5.0.5(rollup@3.29.4)
-      pathe: 1.1.1
-    transitivePeerDependencies:
-      - rollup
-    dev: true
-
   /ast-kit@0.11.2(rollup@3.23.0):
     resolution: {integrity: sha512-Q0DjXK4ApbVoIf9GLyCo252tUH44iTnD/hiJ2TQaJeydYWSpKk0sI34+WMel8S9Wt5pbLgG02oJ+gkgX5DV3sQ==}
     engines: {node: '>=16.14.0'}
     dependencies:
       '@babel/parser': 7.23.0
       '@rollup/pluginutils': 5.0.5(rollup@3.23.0)
-      pathe: 1.1.1
-    transitivePeerDependencies:
-      - rollup
-    dev: true
-
-  /ast-kit@0.9.5:
-    resolution: {integrity: sha512-kbL7ERlqjXubdDd+szuwdlQ1xUxEz9mCz1+m07ftNVStgwRb2RWw+U6oKo08PAvOishMxiqz1mlJyLl8yQx2Qg==}
-    engines: {node: '>=16.14.0'}
-    dependencies:
-      '@babel/parser': 7.23.0
-      '@rollup/pluginutils': 5.0.5(rollup@3.29.4)
       pathe: 1.1.1
     transitivePeerDependencies:
       - rollup
@@ -3887,16 +3685,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       tslib: 2.5.2
-    dev: true
-
-  /ast-walker-scope@0.5.0:
-    resolution: {integrity: sha512-NsyHMxBh4dmdEHjBo1/TBZvCKxffmZxRYhmclfu0PP6Aftre47jOHYaYaNqJcV0bxihxFXhDkzLHUwHc0ocd0Q==}
-    engines: {node: '>=16.14.0'}
-    dependencies:
-      '@babel/parser': 7.23.0
-      ast-kit: 0.9.5
-    transitivePeerDependencies:
-      - rollup
     dev: true
 
   /ast-walker-scope@0.5.0(rollup@3.23.0):
@@ -7737,108 +7525,6 @@ packages:
       - webpack-cli
     dev: true
 
-  /nuxt@3.7.4(eslint@8.51.0):
-    resolution: {integrity: sha512-voXN2kheEpi7DJd0hkikfLuA41UiP9IwDDol65dvoJiHnRseWfaw1MyJl6FLHHDHwRzisX9QXWIyMfa9YF4nGg==}
-    engines: {node: ^14.18.0 || >=16.10.0}
-    hasBin: true
-    peerDependencies:
-      '@parcel/watcher': ^2.1.0
-      '@types/node': ^14.18.0 || >=16.10.0
-    peerDependenciesMeta:
-      '@parcel/watcher':
-        optional: true
-      '@types/node':
-        optional: true
-    dependencies:
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 3.7.4(esbuild@0.19.4)
-      '@nuxt/schema': 3.7.4
-      '@nuxt/telemetry': 2.5.2(esbuild@0.19.4)
-      '@nuxt/ui-templates': 1.3.1
-      '@nuxt/vite-builder': 3.7.4(eslint@8.51.0)(vue@3.3.4)
-      '@unhead/dom': 1.7.4
-      '@unhead/ssr': 1.7.4
-      '@unhead/vue': 1.7.4(vue@3.3.4)
-      '@vue/shared': 3.3.4
-      acorn: 8.10.0
-      c12: 1.4.2
-      chokidar: 3.5.3
-      cookie-es: 1.0.0
-      defu: 6.1.2
-      destr: 2.0.1
-      devalue: 4.3.2
-      esbuild: 0.19.4
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      fs-extra: 11.1.1
-      globby: 13.2.2
-      h3: 1.8.2
-      hookable: 5.5.3
-      jiti: 1.20.0
-      klona: 2.0.6
-      knitwork: 1.0.0
-      magic-string: 0.30.4
-      mlly: 1.4.2
-      nitropack: 2.6.3
-      nuxi: 3.9.0
-      nypm: 0.3.3
-      ofetch: 1.3.3
-      ohash: 1.1.3
-      pathe: 1.1.1
-      perfect-debounce: 1.0.0
-      pkg-types: 1.0.3
-      radix3: 1.1.0
-      scule: 1.0.0
-      std-env: 3.4.3
-      strip-literal: 1.3.0
-      ufo: 1.3.1
-      ultrahtml: 1.5.2
-      uncrypto: 0.1.3
-      unctx: 2.3.1
-      unenv: 1.7.4
-      unimport: 3.4.0
-      unplugin: 1.5.0
-      unplugin-vue-router: 0.7.0(vue-router@4.2.5)(vue@3.3.4)
-      untyped: 1.4.0
-      vue: 3.3.4
-      vue-bundle-renderer: 2.0.0
-      vue-devtools-stub: 0.1.0
-      vue-router: 4.2.5(vue@3.3.4)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@planetscale/database'
-      - '@swc/core'
-      - '@upstash/redis'
-      - '@vercel/kv'
-      - encoding
-      - eslint
-      - idb-keyval
-      - less
-      - lightningcss
-      - meow
-      - optionator
-      - rollup
-      - sass
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - typescript
-      - uglify-js
-      - vls
-      - vti
-      - vue-tsc
-      - webpack-cli
-      - xml2js
-    dev: true
-
   /nuxt@3.7.4(eslint@8.51.0)(rollup@3.23.0)(typescript@5.2.2):
     resolution: {integrity: sha512-voXN2kheEpi7DJd0hkikfLuA41UiP9IwDDol65dvoJiHnRseWfaw1MyJl6FLHHDHwRzisX9QXWIyMfa9YF4nGg==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -10053,24 +9739,6 @@ packages:
       vfile: 6.0.1
     dev: true
 
-  /unimport@3.4.0:
-    resolution: {integrity: sha512-M/lfFEgufIT156QAr/jWHLUn55kEmxBBiQsMxvRSIbquwmeJEyQYgshHDEvQDWlSJrVOOTAgnJ3FvlsrpGkanA==}
-    dependencies:
-      '@rollup/pluginutils': 5.0.5(rollup@3.29.4)
-      escape-string-regexp: 5.0.0
-      fast-glob: 3.3.1
-      local-pkg: 0.4.3
-      magic-string: 0.30.4
-      mlly: 1.4.2
-      pathe: 1.1.1
-      pkg-types: 1.0.3
-      scule: 1.0.0
-      strip-literal: 1.3.0
-      unplugin: 1.5.0
-    transitivePeerDependencies:
-      - rollup
-    dev: true
-
   /unimport@3.4.0(rollup@3.23.0):
     resolution: {integrity: sha512-M/lfFEgufIT156QAr/jWHLUn55kEmxBBiQsMxvRSIbquwmeJEyQYgshHDEvQDWlSJrVOOTAgnJ3FvlsrpGkanA==}
     dependencies:
@@ -10203,33 +9871,6 @@ packages:
       '@rollup/pluginutils': 5.0.5(rollup@3.23.0)
       '@vue-macros/common': 1.8.0(rollup@3.23.0)(vue@3.3.4)
       ast-walker-scope: 0.5.0(rollup@3.23.0)
-      chokidar: 3.5.3
-      fast-glob: 3.3.1
-      json5: 2.2.3
-      local-pkg: 0.4.3
-      mlly: 1.4.2
-      pathe: 1.1.1
-      scule: 1.0.0
-      unplugin: 1.5.0
-      vue-router: 4.2.5(vue@3.3.4)
-      yaml: 2.3.2
-    transitivePeerDependencies:
-      - rollup
-      - vue
-    dev: true
-
-  /unplugin-vue-router@0.7.0(vue-router@4.2.5)(vue@3.3.4):
-    resolution: {integrity: sha512-ddRreGq0t5vlSB7OMy4e4cfU1w2AwBQCwmvW3oP/0IHQiokzbx4hd3TpwBu3eIAFVuhX2cwNQwp1U32UybTVCw==}
-    peerDependencies:
-      vue-router: ^4.1.0
-    peerDependenciesMeta:
-      vue-router:
-        optional: true
-    dependencies:
-      '@babel/types': 7.23.0
-      '@rollup/pluginutils': 5.0.5(rollup@3.29.4)
-      '@vue-macros/common': 1.8.0(vue@3.3.4)
-      ast-walker-scope: 0.5.0
       chokidar: 3.5.3
       fast-glob: 3.3.1
       json5: 2.2.3


### PR DESCRIPTION
Running it without the subcommand is deprecated and may break in the future.