### PR TITLE
Switch to using module ID markers

### DIFF
--- a/.changeset/sharp-months-brush.md
+++ b/.changeset/sharp-months-brush.md
@@ -1,0 +1,9 @@
+---
+'@vintl/nuxt': minor
+---
+
+Switched to using module ID markers
+
+Previously VIntl for Nuxt kept track of files that were used as locale messages and matched module IDs based on them. This, however, was very unreliable in certain environments.
+
+With this change VIntl for Nuxt now uses ‘markers’, URL parameters added to the end of imported module IDs. This allows it to very quickly test whether a specific module is imported through a message file and should be processed by the VIntl unplugin.

--- a/packages/vintl-nuxt/src/module.ts
+++ b/packages/vintl-nuxt/src/module.ts
@@ -96,7 +96,7 @@ export default defineNuxtModule<ModuleOptions>({
               return resolveInResDir(specifier).relativeTo(optionsFile.dst)
             },
             registerMessagesFile(file, importPath) {
-              pluginOptionsBank.registerFile(
+              return pluginOptionsBank.registerFile(
                 file,
                 resolvePath(dirname(optionsFile.dst), importPath),
               )

--- a/packages/vintl-nuxt/src/options-gen.ts
+++ b/packages/vintl-nuxt/src/options-gen.ts
@@ -623,11 +623,12 @@ interface GeneratorContext {
    *
    * @param file Input message file options.
    * @param importPath Resolved path.
+   * @returns Marked import path.
    */
   registerMessagesFile(
     file: t.output<typeof messagesImportSourceSchema>,
     importPath: string,
-  ): void
+  ): string
 
   /**
    * Resolves a module from the runtime directory.
@@ -780,8 +781,10 @@ export function generate(
 
     for (const messageFile of files) {
       const { from: importPath, name: importKey } = messageFile
-      const resolvedPath = resolve(messageFile.from)
-      registerMessagesFile(messageFile, resolvedPath)
+      const resolvedPath = registerMessagesFile(
+        messageFile,
+        resolve(messageFile.from),
+      )
 
       if (isDefaultLocale) {
         // if import key is 'default' then:


### PR DESCRIPTION
Previously VIntl for Nuxt kept track of files that were used as locale
messages and matched module IDs based on them. This, however, was very
unreliable in certain environments.

With this change VIntl for Nuxt now uses 'markers', URL parameters added
to the end of imported module IDs. This allows it to very quickly test
whether a specific module is imported through a message file and should
be processed by the VIntl unplugin.
