### PR TITLE
fix: augment `#app` rather than `nuxt/app`

### DIFF
--- a/packages/vintl-nuxt/src/runtime/plugin.ts
+++ b/packages/vintl-nuxt/src/runtime/plugin.ts
@@ -163,7 +163,7 @@ type EventContext<E> = {
   controller: IntlController<MessageValueType>
 }
 
-declare module 'nuxt/app' {
+declare module '#app' {
   interface NuxtApp
     extends InjectedProperties<VueIntlController.MessageValueTypes> {}
 


### PR DESCRIPTION
We're seeing some cases where when users augment `#app/nuxt` rather than `#app`, they can lose type support once the (future default) typescript module resolution of 'bundler' is enabled.

While searching for repos using that, I also came across this usage (`nuxt/app`). While it should be fine, I thought it would still be worth raising this PR for you to consider, in case it might prevent issues in future.

related: https://github.com/nuxt/nuxt/issues/24193