### PR TITLE
Fix incorrect check for window in global-vintl docs plugin

### DIFF
--- a/apps/docs/plugins/global-vintl.ts
+++ b/apps/docs/plugins/global-vintl.ts
@@ -1,6 +1,11 @@
 export default defineNuxtPlugin((nuxtApp) => {
   if (process.client && typeof window !== null) {
-    ;(window as any).vintl = nuxtApp.$i18n
+    Object.defineProperty(window, 'vintl', {
+      configurable: true,
+      writable: true,
+      enumerable: true,
+      value: nuxtApp.$i18n,
+    })
     console.log('~'.repeat(80))
     console.log('%cHey there! 👋', 'font-size: 1.2rem')
     console.log(

--- a/apps/docs/plugins/global-vintl.ts
+++ b/apps/docs/plugins/global-vintl.ts
@@ -1,5 +1,5 @@
 export default defineNuxtPlugin((nuxtApp) => {
-  if (process.client && typeof window !== null) {
+  if (process.client && typeof window !== 'undefined') {
     Object.defineProperty(window, 'vintl', {
       configurable: true,
       writable: true,


### PR DESCRIPTION
- Change how the global vintl var in docs is defined
- Fix incorrect check for window in global-vintl docs plugin
