### PR TITLE
Fix TypeScript error about usage of `noEmit`

### DIFF
--- a/packages/vintl-nuxt/tsconfig.build.json
+++ b/packages/vintl-nuxt/tsconfig.build.json
@@ -13,7 +13,7 @@
 
     "allowJs": true,
 
-    "noEmit": true
+    "emitDeclarationOnly": true
   },
   "include": ["./build.config.ts", "./eslint.config.mjs"]
 }


### PR DESCRIPTION
- **chore(deps): update all non-major dependencies**
- **Export ModuleOptions for Nuxt module builder**
- **Fix TypeScript error about usage of `noEmit`**
