### PR TITLE
Generate runtime options file using Babel

### DIFF
--- a/.changeset/tough-horses-chew.md
+++ b/.changeset/tough-horses-chew.md
@@ -1,0 +1,5 @@
+---
+'@vintl/nuxt': patch
+---
+
+Switch to Babel for runtime options generation

--- a/packages/vintl-nuxt/package.json
+++ b/packages/vintl-nuxt/package.json
@@ -49,6 +49,7 @@
     "@nuxt/eslint-config": "^0.6.0",
     "@nuxt/module-builder": "^0.8.4",
     "@nuxt/schema": "^3.13.2",
+    "@types/babel__generator": "^7.6.8",
     "@types/hash-sum": "^1.0.2",
     "@types/node": "^18.19.56",
     "@vintl-dev/eslint-config-peony": "workspace:^",
@@ -57,12 +58,13 @@
     "vue-tsc": "^2.1.6"
   },
   "dependencies": {
+    "@babel/generator": "^7.25.9",
+    "@babel/types": "^7.25.9",
     "@formatjs/intl": "^2.10.8",
     "@formatjs/intl-localematcher": "^0.5.5",
     "@nuxt/kit": "^3.13.2",
     "@vintl/unplugin": "^2.0.0",
     "@vintl/vintl": "^4.4.1",
-    "astring": "^1.9.0",
     "consola": "^3.2.3",
     "hash-sum": "^2.0.0",
     "import-meta-resolve": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,16 +31,16 @@ importers:
         version: 6.3.0(@vue/compiler-core@3.5.12)(vue@3.5.12(typescript@5.6.3))
       '@nuxt/content':
         specifier: ^2.13.4
-        version: 2.13.4(esbuild@0.21.5)(ioredis@5.4.1)(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.19.0)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue-tsc@2.1.6(typescript@5.6.3))(webpack-sources@3.2.3))(rollup@4.19.0)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
+        version: 2.13.4(esbuild@0.21.5)(ioredis@5.4.1)(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.5)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3))(rollup@4.22.5)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
       '@nuxt/eslint':
         specifier: ^0.6.0
-        version: 0.6.0(esbuild@0.21.5)(eslint@9.12.0(jiti@2.3.3))(magicast@0.3.5)(rollup@4.19.0)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)
+        version: 0.6.0(esbuild@0.21.5)(eslint@9.12.0(jiti@2.3.3))(magicast@0.3.5)(rollup@4.22.5)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)
       '@nuxt/eslint-config':
         specifier: ^0.6.0
         version: 0.6.0(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)
       '@nuxt/icon':
         specifier: ^1.5.6
-        version: 1.5.6(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
+        version: 1.5.6(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.22.5)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
       '@vintl-dev/eslint-config-peony':
         specifier: workspace:^
         version: link:../../packages/eslint-config
@@ -52,7 +52,7 @@ importers:
         version: 9.12.0(jiti@2.3.3)
       nuxt:
         specifier: ^3.13.2
-        version: 3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.19.0)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue-tsc@2.1.6(typescript@5.6.3))(webpack-sources@3.2.3)
+        version: 3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.5)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)
       vue:
         specifier: ^3.5.12
         version: 3.5.12(typescript@5.6.3)
@@ -79,7 +79,7 @@ importers:
         version: 3.14.0
       nuxt:
         specifier: ^3.13.2
-        version: 3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.5)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue-tsc@2.1.6(typescript@5.6.3))(webpack-sources@3.2.3)
+        version: 3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.5)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)
 
   packages/eslint-config:
     dependencies:
@@ -98,6 +98,12 @@ importers:
 
   packages/vintl-nuxt:
     dependencies:
+      '@babel/generator':
+        specifier: ^7.25.9
+        version: 7.25.9
+      '@babel/types':
+        specifier: ^7.25.9
+        version: 7.25.9
       '@formatjs/intl':
         specifier: ^2.10.8
         version: 2.10.8(typescript@5.6.3)
@@ -106,16 +112,13 @@ importers:
         version: 0.5.5
       '@nuxt/kit':
         specifier: ^3.13.2
-        version: 3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)
+        version: 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)
       '@vintl/unplugin':
         specifier: ^2.0.0
-        version: 2.0.0(@vue/compiler-core@3.5.12)(rollup@3.29.4)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack@5.83.1)
+        version: 2.0.0(@vue/compiler-core@3.5.12)(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack@5.83.1)
       '@vintl/vintl':
         specifier: ^4.4.1
         version: 4.4.1(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))
-      astring:
-        specifier: ^1.9.0
-        version: 1.9.0
       consola:
         specifier: ^3.2.3
         version: 3.2.3
@@ -140,16 +143,19 @@ importers:
     devDependencies:
       '@nuxt/devtools':
         specifier: ^1.6.0
-        version: 1.6.0(rollup@3.29.4)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
+        version: 1.6.0(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
       '@nuxt/eslint-config':
         specifier: ^0.6.0
         version: 0.6.0(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)
       '@nuxt/module-builder':
         specifier: ^0.8.4
-        version: 0.8.4(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3))(nuxi@3.14.0)(typescript@5.6.3)
+        version: 0.8.4(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3))(nuxi@3.14.0)(typescript@5.6.3)
       '@nuxt/schema':
         specifier: ^3.13.2
-        version: 3.13.2(rollup@3.29.4)(webpack-sources@3.2.3)
+        version: 3.13.2(rollup@4.19.0)(webpack-sources@3.2.3)
+      '@types/babel__generator':
+        specifier: ^7.6.8
+        version: 7.6.8
       '@types/hash-sum':
         specifier: ^1.0.2
         version: 1.0.2
@@ -161,7 +167,7 @@ importers:
         version: link:../eslint-config
       nuxt:
         specifier: ^3.13.2
-        version: 3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@3.29.4)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue-tsc@2.1.6(typescript@5.6.3))(webpack-sources@3.2.3)
+        version: 3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.19.0)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue-tsc@2.1.6(typescript@5.6.3))(webpack-sources@3.2.3)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -201,8 +207,8 @@ packages:
     resolution: {integrity: sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.24.7':
-    resolution: {integrity: sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==}
+  '@babel/generator@7.25.9':
+    resolution: {integrity: sha512-omlUGkr5EaoIJrhLf9CJ0TvjBRpd9+AXRG//0GEQ9THSo8wPiTlbpy1/Ow8ZTrbXpjd9FHXfbFQx32I04ht0FA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.24.7':
@@ -275,12 +281,16 @@ packages:
     resolution: {integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.24.8':
-    resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
+  '@babel/helper-string-parser@7.25.9':
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.24.7':
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.24.7':
@@ -357,12 +367,8 @@ packages:
     resolution: {integrity: sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.25.0':
-    resolution: {integrity: sha512-LcnxQSsd9aXOIgmmSpvZ/1yo46ra2ESYyqLcryaBZOghxy5qqOBjvCWP5JfkI8yl9rlxRgdLTTMCQQRcN2hdCg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.25.6':
-    resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
+  '@babel/types@7.25.9':
+    resolution: {integrity: sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==}
     engines: {node: '>=6.9.0'}
 
   '@braw/async-computed@5.0.2':
@@ -1328,9 +1334,6 @@ packages:
   '@jridgewell/source-map@0.3.3':
     resolution: {integrity: sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==}
 
-  '@jridgewell/sourcemap-codec@1.4.15':
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
@@ -1863,6 +1866,9 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
+  '@types/babel__generator@7.6.8':
+    resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
+
   '@types/debug@4.1.8':
     resolution: {integrity: sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==}
 
@@ -2369,10 +2375,6 @@ packages:
   ast-walker-scope@0.6.2:
     resolution: {integrity: sha512-1UWOyC50xI3QZkRuDj6PqDtpm1oHWtYs+NQGwqL/2R11eN3Q81PHAHPM0SWW3BNQm53UDwS//Jv8L4CCVLM1bQ==}
     engines: {node: '>=16.14.0'}
-
-  astring@1.9.0:
-    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
-    hasBin: true
 
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
@@ -3686,11 +3688,6 @@ packages:
 
   jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
-    hasBin: true
-
-  jsesc@2.5.2:
-    resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
-    engines: {node: '>=4'}
     hasBin: true
 
   jsesc@3.0.2:
@@ -5151,10 +5148,6 @@ packages:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
 
-  to-fast-properties@2.0.0:
-    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
-    engines: {node: '>=4'}
-
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -5191,9 +5184,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  tslib@2.6.3:
-    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
   tslib@2.8.0:
     resolution: {integrity: sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==}
@@ -5778,14 +5768,14 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.24.7
+      '@babel/generator': 7.25.9
       '@babel/helper-compilation-targets': 7.24.7
       '@babel/helper-module-transforms': 7.24.7(@babel/core@7.24.7)
       '@babel/helpers': 7.24.7
       '@babel/parser': 7.25.6
       '@babel/template': 7.24.7
       '@babel/traverse': 7.24.7
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
       convert-source-map: 2.0.0
       debug: 4.3.7
       gensync: 1.0.0-beta.2
@@ -5794,16 +5784,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.24.7':
+  '@babel/generator@7.25.9':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
-      jsesc: 2.5.2
+      jsesc: 3.0.2
 
   '@babel/helper-annotate-as-pure@7.24.7':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
 
   '@babel/helper-compilation-targets@7.24.7':
     dependencies:
@@ -5830,32 +5820,32 @@ snapshots:
 
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
 
   '@babel/helper-function-name@7.24.7':
     dependencies:
       '@babel/template': 7.24.7
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
 
   '@babel/helper-hoist-variables@7.24.7':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
 
   '@babel/helper-member-expression-to-functions@7.24.7':
     dependencies:
       '@babel/traverse': 7.24.7
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.22.15':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
 
   '@babel/helper-module-imports@7.24.7':
     dependencies:
       '@babel/traverse': 7.24.7
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
@@ -5872,7 +5862,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.24.7':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
 
   '@babel/helper-plugin-utils@7.24.7': {}
 
@@ -5888,31 +5878,33 @@ snapshots:
   '@babel/helper-simple-access@7.24.7':
     dependencies:
       '@babel/traverse': 7.24.7
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.24.7':
     dependencies:
       '@babel/traverse': 7.24.7
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
 
-  '@babel/helper-string-parser@7.24.8': {}
+  '@babel/helper-string-parser@7.25.9': {}
 
   '@babel/helper-validator-identifier@7.24.7': {}
+
+  '@babel/helper-validator-identifier@7.25.9': {}
 
   '@babel/helper-validator-option@7.24.7': {}
 
   '@babel/helpers@7.24.7':
     dependencies:
       '@babel/template': 7.24.7
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
 
   '@babel/highlight@7.24.7':
     dependencies:
@@ -5923,7 +5915,7 @@ snapshots:
 
   '@babel/parser@7.25.6':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
 
   '@babel/plugin-proposal-decorators@7.23.2(@babel/core@7.24.7)':
     dependencies:
@@ -5981,34 +5973,27 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/parser': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
 
   '@babel/traverse@7.24.7':
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.24.7
+      '@babel/generator': 7.25.9
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-hoist-variables': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/parser': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
       debug: 4.3.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.25.0':
+  '@babel/types@7.25.9':
     dependencies:
-      '@babel/helper-string-parser': 7.24.8
-      '@babel/helper-validator-identifier': 7.24.7
-      to-fast-properties: 2.0.0
-
-  '@babel/types@7.25.6':
-    dependencies:
-      '@babel/helper-string-parser': 7.24.8
-      '@babel/helper-validator-identifier': 7.24.7
-      to-fast-properties: 2.0.0
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
 
   '@braw/async-computed@5.0.2(vue@3.5.12(typescript@5.6.3))':
     dependencies:
@@ -6598,7 +6583,7 @@ snapshots:
       fs-extra: 10.1.0
       json-stable-stringify: 1.0.2
       loud-rejection: 2.2.0
-      tslib: 2.6.3
+      tslib: 2.8.0
       typescript: 5.6.3
     optionalDependencies:
       '@vue/compiler-core': 3.5.12
@@ -6614,12 +6599,12 @@ snapshots:
   '@formatjs/ecma402-abstract@1.17.2':
     dependencies:
       '@formatjs/intl-localematcher': 0.4.2
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@formatjs/ecma402-abstract@1.18.0':
     dependencies:
       '@formatjs/intl-localematcher': 0.5.2
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@formatjs/ecma402-abstract@2.2.0':
     dependencies:
@@ -6629,7 +6614,7 @@ snapshots:
 
   '@formatjs/fast-memoize@2.2.0':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@formatjs/fast-memoize@2.2.1':
     dependencies:
@@ -6639,7 +6624,7 @@ snapshots:
     dependencies:
       '@formatjs/ecma402-abstract': 1.17.2
       '@formatjs/icu-skeleton-parser': 1.6.2
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@formatjs/icu-messageformat-parser@2.7.10':
     dependencies:
@@ -6651,17 +6636,17 @@ snapshots:
     dependencies:
       '@formatjs/ecma402-abstract': 1.18.0
       '@formatjs/icu-skeleton-parser': 1.7.0
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@formatjs/icu-skeleton-parser@1.6.2':
     dependencies:
       '@formatjs/ecma402-abstract': 1.17.2
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@formatjs/icu-skeleton-parser@1.7.0':
     dependencies:
       '@formatjs/ecma402-abstract': 1.18.0
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@formatjs/icu-skeleton-parser@1.8.4':
     dependencies:
@@ -6682,11 +6667,11 @@ snapshots:
 
   '@formatjs/intl-localematcher@0.4.2':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@formatjs/intl-localematcher@0.5.2':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@formatjs/intl-localematcher@0.5.5':
     dependencies:
@@ -6711,7 +6696,7 @@ snapshots:
       '@types/node': 17.0.45
       chalk: 4.1.2
       json-stable-stringify: 1.0.2
-      tslib: 2.6.3
+      tslib: 2.8.0
       typescript: 5.6.3
 
   '@humanfs/core@0.19.0': {}
@@ -6762,7 +6747,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
       '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/resolve-uri@3.1.0': {}
@@ -6774,14 +6759,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@jridgewell/sourcemap-codec@1.4.15': {}
-
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@jsdevtools/ono@7.1.3': {}
 
@@ -6859,13 +6842,13 @@ snapshots:
       '@nodelib/fs.scandir': 3.0.0
       fastq: 1.15.0
 
-  '@nuxt/content@2.13.4(esbuild@0.21.5)(ioredis@5.4.1)(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.19.0)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue-tsc@2.1.6(typescript@5.6.3))(webpack-sources@3.2.3))(rollup@4.19.0)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)':
+  '@nuxt/content@2.13.4(esbuild@0.21.5)(ioredis@5.4.1)(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.5)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3))(rollup@4.22.5)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)':
     dependencies:
-      '@nuxt/kit': 3.13.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)
-      '@nuxtjs/mdc': 0.9.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.13.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)
+      '@nuxtjs/mdc': 0.9.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)
       '@vueuse/core': 11.1.0(vue@3.5.12(typescript@5.6.3))
       '@vueuse/head': 2.0.0(vue@3.5.12(typescript@5.6.3))
-      '@vueuse/nuxt': 11.1.0(esbuild@0.21.5)(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.19.0)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue-tsc@2.1.6(typescript@5.6.3))(webpack-sources@3.2.3))(rollup@4.19.0)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
+      '@vueuse/nuxt': 11.1.0(esbuild@0.21.5)(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.5)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3))(rollup@4.22.5)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
       consola: 3.2.3
       defu: 6.1.4
       destr: 2.0.3
@@ -6919,22 +6902,6 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.5.1(esbuild@0.23.1)(magicast@0.3.5)(rollup@3.29.4)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)':
-    dependencies:
-      '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)
-      '@nuxt/schema': 3.13.2(rollup@3.29.4)(webpack-sources@3.2.3)
-      execa: 7.2.0
-      vite: 5.4.8(@types/node@18.19.57)(terser@5.17.6)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - magicast
-      - rollup
-      - supports-color
-      - uglify-js
-      - webpack-cli
-      - webpack-sources
-
   '@nuxt/devtools-kit@1.5.1(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)':
     dependencies:
       '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)
@@ -6967,10 +6934,10 @@ snapshots:
       - webpack-cli
       - webpack-sources
 
-  '@nuxt/devtools-kit@1.5.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)':
+  '@nuxt/devtools-kit@1.5.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.22.5)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)':
     dependencies:
-      '@nuxt/kit': 3.13.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)
-      '@nuxt/schema': 3.13.2(rollup@4.19.0)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.13.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)
+      '@nuxt/schema': 3.13.2(rollup@4.22.5)(webpack-sources@3.2.3)
       execa: 7.2.0
       vite: 5.4.8(@types/node@18.19.57)(terser@5.17.6)
     transitivePeerDependencies:
@@ -6985,7 +6952,7 @@ snapshots:
 
   '@nuxt/devtools-kit@1.5.2(magicast@0.3.5)(rollup@4.22.5)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)':
     dependencies:
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)
       '@nuxt/schema': 3.13.2(rollup@4.22.5)(webpack-sources@3.2.3)
       execa: 7.2.0
       vite: 5.4.8(@types/node@18.19.57)(terser@5.17.6)
@@ -6999,10 +6966,10 @@ snapshots:
       - webpack-cli
       - webpack-sources
 
-  '@nuxt/devtools-kit@1.6.0(magicast@0.3.5)(rollup@3.29.4)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)':
+  '@nuxt/devtools-kit@1.6.0(magicast@0.3.5)(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)':
     dependencies:
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)
-      '@nuxt/schema': 3.13.2(rollup@3.29.4)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)
+      '@nuxt/schema': 3.13.2(rollup@4.19.0)(webpack-sources@3.2.3)
       execa: 7.2.0
       vite: 5.4.8(@types/node@18.19.57)(terser@5.17.6)
     transitivePeerDependencies:
@@ -7041,58 +7008,6 @@ snapshots:
       rc9: 2.1.2
       semver: 7.6.3
 
-  '@nuxt/devtools@1.5.1(esbuild@0.23.1)(rollup@3.29.4)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)':
-    dependencies:
-      '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.5.1(esbuild@0.23.1)(magicast@0.3.5)(rollup@3.29.4)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)
-      '@nuxt/devtools-wizard': 1.5.1
-      '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)
-      '@vue/devtools-core': 7.4.4(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))
-      '@vue/devtools-kit': 7.4.4
-      birpc: 0.2.17
-      consola: 3.2.3
-      cronstrue: 2.50.0
-      destr: 2.0.3
-      error-stack-parser-es: 0.1.5
-      execa: 7.2.0
-      fast-npm-meta: 0.2.2
-      flatted: 3.3.1
-      get-port-please: 3.1.2
-      hookable: 5.5.3
-      image-meta: 0.2.1
-      is-installed-globally: 1.0.0
-      launch-editor: 2.9.1
-      local-pkg: 0.5.0
-      magicast: 0.3.5
-      nypm: 0.3.12
-      ohash: 1.1.4
-      pathe: 1.1.2
-      perfect-debounce: 1.0.0
-      pkg-types: 1.2.0
-      rc9: 2.1.2
-      scule: 1.3.0
-      semver: 7.6.3
-      simple-git: 3.27.0
-      sirv: 2.0.4
-      tinyglobby: 0.2.7
-      unimport: 3.13.1(rollup@3.29.4)(webpack-sources@3.2.3)
-      vite: 5.4.8(@types/node@18.19.57)(terser@5.17.6)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3))(rollup@3.29.4)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))
-      vite-plugin-vue-inspector: 5.2.0(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))
-      which: 3.0.1
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - bufferutil
-      - esbuild
-      - rollup
-      - supports-color
-      - uglify-js
-      - utf-8-validate
-      - vue
-      - webpack-cli
-      - webpack-sources
-
   '@nuxt/devtools@1.5.1(esbuild@0.23.1)(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)':
     dependencies:
       '@antfu/utils': 0.7.10
@@ -7129,7 +7044,7 @@ snapshots:
       tinyglobby: 0.2.7
       unimport: 3.13.1(rollup@4.19.0)(webpack-sources@3.2.3)
       vite: 5.4.8(@types/node@18.19.57)(terser@5.17.6)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3))(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))
+      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3))(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))
       vite-plugin-vue-inspector: 5.2.0(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))
       which: 3.0.1
       ws: 8.18.0
@@ -7197,12 +7112,12 @@ snapshots:
       - webpack-cli
       - webpack-sources
 
-  '@nuxt/devtools@1.6.0(rollup@3.29.4)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)':
+  '@nuxt/devtools@1.6.0(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.6.0(magicast@0.3.5)(rollup@3.29.4)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)
+      '@nuxt/devtools-kit': 1.6.0(magicast@0.3.5)(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)
       '@nuxt/devtools-wizard': 1.6.0
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)
       '@vue/devtools-core': 7.4.4(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))
       '@vue/devtools-kit': 7.4.4
       birpc: 0.2.17
@@ -7231,9 +7146,9 @@ snapshots:
       simple-git: 3.27.0
       sirv: 2.0.4
       tinyglobby: 0.2.7
-      unimport: 3.13.1(rollup@3.29.4)(webpack-sources@3.2.3)
+      unimport: 3.13.1(rollup@4.19.0)(webpack-sources@3.2.3)
       vite: 5.4.8(@types/node@18.19.57)(terser@5.17.6)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3))(rollup@3.29.4)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))
+      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3))(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))
       vite-plugin-vue-inspector: 5.1.3(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))
       which: 3.0.1
       ws: 8.18.0
@@ -7281,44 +7196,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/eslint@0.6.0(esbuild@0.21.5)(eslint@9.12.0(jiti@2.3.3))(magicast@0.3.5)(rollup@4.19.0)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)':
+  '@nuxt/eslint@0.6.0(esbuild@0.21.5)(eslint@9.12.0(jiti@2.3.3))(magicast@0.3.5)(rollup@4.22.5)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)':
     dependencies:
       '@eslint/config-inspector': 0.5.4(eslint@9.12.0(jiti@2.3.3))
-      '@nuxt/devtools-kit': 1.5.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)
+      '@nuxt/devtools-kit': 1.5.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.22.5)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)
       '@nuxt/eslint-config': 0.6.0(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)
       '@nuxt/eslint-plugin': 0.6.0(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)
-      '@nuxt/kit': 3.13.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)
-      chokidar: 4.0.1
-      eslint: 9.12.0(jiti@2.3.3)
-      eslint-flat-config-utils: 0.4.0
-      eslint-typegen: 0.3.2(eslint@9.12.0(jiti@2.3.3))
-      find-up: 7.0.0
-      get-port-please: 3.1.2
-      mlly: 1.7.2
-      pathe: 1.1.2
-      unimport: 3.13.1(rollup@4.19.0)(webpack-sources@3.2.3)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - bufferutil
-      - esbuild
-      - magicast
-      - rollup
-      - supports-color
-      - typescript
-      - uWebSockets.js
-      - uglify-js
-      - utf-8-validate
-      - vite
-      - webpack-cli
-      - webpack-sources
-
-  '@nuxt/eslint@0.6.0(eslint@9.12.0(jiti@2.3.3))(magicast@0.3.5)(rollup@4.22.5)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)':
-    dependencies:
-      '@eslint/config-inspector': 0.5.4(eslint@9.12.0(jiti@2.3.3))
-      '@nuxt/devtools-kit': 1.5.2(magicast@0.3.5)(rollup@4.22.5)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)
-      '@nuxt/eslint-config': 0.6.0(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)
-      '@nuxt/eslint-plugin': 0.6.0(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.13.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)
       chokidar: 4.0.1
       eslint: 9.12.0(jiti@2.3.3)
       eslint-flat-config-utils: 0.4.0
@@ -7343,14 +7227,45 @@ snapshots:
       - webpack-cli
       - webpack-sources
 
-  '@nuxt/icon@1.5.6(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)':
+  '@nuxt/eslint@0.6.0(eslint@9.12.0(jiti@2.3.3))(magicast@0.3.5)(rollup@4.22.5)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)':
+    dependencies:
+      '@eslint/config-inspector': 0.5.4(eslint@9.12.0(jiti@2.3.3))
+      '@nuxt/devtools-kit': 1.5.2(magicast@0.3.5)(rollup@4.22.5)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)
+      '@nuxt/eslint-config': 0.6.0(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)
+      '@nuxt/eslint-plugin': 0.6.0(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)
+      '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)
+      chokidar: 4.0.1
+      eslint: 9.12.0(jiti@2.3.3)
+      eslint-flat-config-utils: 0.4.0
+      eslint-typegen: 0.3.2(eslint@9.12.0(jiti@2.3.3))
+      find-up: 7.0.0
+      get-port-please: 3.1.2
+      mlly: 1.7.2
+      pathe: 1.1.2
+      unimport: 3.13.1(rollup@4.22.5)(webpack-sources@3.2.3)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - bufferutil
+      - esbuild
+      - magicast
+      - rollup
+      - supports-color
+      - typescript
+      - uWebSockets.js
+      - uglify-js
+      - utf-8-validate
+      - vite
+      - webpack-cli
+      - webpack-sources
+
+  '@nuxt/icon@1.5.6(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.22.5)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)':
     dependencies:
       '@iconify/collections': 1.0.472
       '@iconify/types': 2.0.0
       '@iconify/utils': 2.1.33
       '@iconify/vue': 4.1.3-beta.1(vue@3.5.12(typescript@5.6.3))
-      '@nuxt/devtools-kit': 1.5.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)
-      '@nuxt/kit': 3.13.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)
+      '@nuxt/devtools-kit': 1.5.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.22.5)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.13.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)
       consola: 3.2.3
       local-pkg: 0.5.0
       mlly: 1.7.2
@@ -7370,9 +7285,9 @@ snapshots:
       - webpack-cli
       - webpack-sources
 
-  '@nuxt/kit@3.13.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)':
+  '@nuxt/kit@3.13.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)':
     dependencies:
-      '@nuxt/schema': 3.13.2(rollup@4.19.0)(webpack-sources@3.2.3)
+      '@nuxt/schema': 3.13.2(rollup@4.22.5)(webpack-sources@3.2.3)
       c12: 1.11.2(magicast@0.3.5)
       consola: 3.2.3
       defu: 6.1.4
@@ -7390,42 +7305,9 @@ snapshots:
       semver: 7.6.3
       ufo: 1.5.4
       unctx: 2.3.1(webpack-sources@3.2.3)
-      unimport: 3.13.1(rollup@4.19.0)(webpack-sources@3.2.3)
+      unimport: 3.13.1(rollup@4.22.5)(webpack-sources@3.2.3)
       untyped: 1.4.2
       webpack: 5.83.1(esbuild@0.21.5)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - magicast
-      - rollup
-      - supports-color
-      - uglify-js
-      - webpack-cli
-      - webpack-sources
-
-  '@nuxt/kit@3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)':
-    dependencies:
-      '@nuxt/schema': 3.13.2(rollup@3.29.4)(webpack-sources@3.2.3)
-      c12: 1.11.2(magicast@0.3.5)
-      consola: 3.2.3
-      defu: 6.1.4
-      destr: 2.0.3
-      globby: 14.0.2
-      hash-sum: 2.0.0
-      ignore: 5.3.2
-      jiti: 1.21.6
-      klona: 2.0.6
-      knitwork: 1.1.0
-      mlly: 1.7.1
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      scule: 1.3.0
-      semver: 7.6.3
-      ufo: 1.5.4
-      unctx: 2.3.1(webpack-sources@3.2.3)
-      unimport: 3.13.1(rollup@3.29.4)(webpack-sources@3.2.3)
-      untyped: 1.4.2
-      webpack: 5.83.1(esbuild@0.23.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -7502,75 +7384,9 @@ snapshots:
       - webpack-cli
       - webpack-sources
 
-  '@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)':
+  '@nuxt/module-builder@0.8.4(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3))(nuxi@3.14.0)(typescript@5.6.3)':
     dependencies:
-      '@nuxt/schema': 3.13.2(rollup@3.29.4)(webpack-sources@3.2.3)
-      c12: 1.11.2(magicast@0.3.5)
-      consola: 3.2.3
-      defu: 6.1.4
-      destr: 2.0.3
-      globby: 14.0.2
-      hash-sum: 2.0.0
-      ignore: 5.3.2
-      jiti: 1.21.6
-      klona: 2.0.6
-      knitwork: 1.1.0
-      mlly: 1.7.1
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      scule: 1.3.0
-      semver: 7.6.3
-      ufo: 1.5.4
-      unctx: 2.3.1(webpack-sources@3.2.3)
-      unimport: 3.13.1(rollup@3.29.4)(webpack-sources@3.2.3)
-      untyped: 1.4.2
-      webpack: 5.83.1
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - magicast
-      - rollup
-      - supports-color
-      - uglify-js
-      - webpack-cli
-      - webpack-sources
-
-  '@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)':
-    dependencies:
-      '@nuxt/schema': 3.13.2(rollup@4.22.5)(webpack-sources@3.2.3)
-      c12: 1.11.2(magicast@0.3.5)
-      consola: 3.2.3
-      defu: 6.1.4
-      destr: 2.0.3
-      globby: 14.0.2
-      hash-sum: 2.0.0
-      ignore: 5.3.2
-      jiti: 1.21.6
-      klona: 2.0.6
-      knitwork: 1.1.0
-      mlly: 1.7.1
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      scule: 1.3.0
-      semver: 7.6.3
-      ufo: 1.5.4
-      unctx: 2.3.1(webpack-sources@3.2.3)
-      unimport: 3.13.1(rollup@4.22.5)(webpack-sources@3.2.3)
-      untyped: 1.4.2
-      webpack: 5.83.1
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - magicast
-      - rollup
-      - supports-color
-      - uglify-js
-      - webpack-cli
-      - webpack-sources
-
-  '@nuxt/module-builder@0.8.4(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3))(nuxi@3.14.0)(typescript@5.6.3)':
-    dependencies:
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)
       citty: 0.1.6
       consola: 3.2.3
       defu: 6.1.4
@@ -7585,25 +7401,6 @@ snapshots:
       - sass
       - supports-color
       - typescript
-
-  '@nuxt/schema@3.13.2(rollup@3.29.4)(webpack-sources@3.2.3)':
-    dependencies:
-      compatx: 0.1.8
-      consola: 3.2.3
-      defu: 6.1.4
-      hookable: 5.5.3
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      scule: 1.3.0
-      std-env: 3.7.0
-      ufo: 1.5.4
-      uncrypto: 0.1.3
-      unimport: 3.13.1(rollup@3.29.4)(webpack-sources@3.2.3)
-      untyped: 1.4.2
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-      - webpack-sources
 
   '@nuxt/schema@3.13.2(rollup@4.19.0)(webpack-sources@3.2.3)':
     dependencies:
@@ -7641,36 +7438,6 @@ snapshots:
     transitivePeerDependencies:
       - rollup
       - supports-color
-      - webpack-sources
-
-  '@nuxt/telemetry@2.6.0(esbuild@0.23.1)(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)':
-    dependencies:
-      '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)
-      ci-info: 4.0.0
-      consola: 3.2.3
-      create-require: 1.1.1
-      defu: 6.1.4
-      destr: 2.0.3
-      dotenv: 16.4.5
-      git-url-parse: 15.0.0
-      is-docker: 3.0.0
-      jiti: 1.21.6
-      mri: 1.2.0
-      nanoid: 5.0.7
-      ofetch: 1.3.4
-      package-manager-detector: 0.2.0
-      parse-git-config: 3.0.0
-      pathe: 1.1.2
-      rc9: 2.1.2
-      std-env: 3.7.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - magicast
-      - rollup
-      - supports-color
-      - uglify-js
-      - webpack-cli
       - webpack-sources
 
   '@nuxt/telemetry@2.6.0(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)':
@@ -7730,69 +7497,6 @@ snapshots:
       - rollup
       - supports-color
       - uglify-js
-      - webpack-cli
-      - webpack-sources
-
-  '@nuxt/vite-builder@3.13.2(@types/node@18.19.57)(eslint@9.12.0(jiti@2.3.3))(magicast@0.3.5)(optionator@0.9.3)(rollup@3.29.4)(terser@5.17.6)(typescript@5.6.3)(vue-tsc@2.1.6(typescript@5.6.3))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)':
-    dependencies:
-      '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)
-      '@rollup/plugin-replace': 5.0.7(rollup@3.29.4)
-      '@vitejs/plugin-vue': 5.1.4(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))
-      '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))
-      autoprefixer: 10.4.20(postcss@8.4.47)
-      clear: 0.1.0
-      consola: 3.2.3
-      cssnano: 7.0.6(postcss@8.4.47)
-      defu: 6.1.4
-      esbuild: 0.23.1
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      externality: 1.0.2
-      get-port-please: 3.1.2
-      h3: 1.12.0
-      knitwork: 1.1.0
-      magic-string: 0.30.11
-      mlly: 1.7.1
-      ohash: 1.1.4
-      pathe: 1.1.2
-      perfect-debounce: 1.0.0
-      pkg-types: 1.2.0
-      postcss: 8.4.47
-      rollup-plugin-visualizer: 5.12.0(rollup@3.29.4)
-      std-env: 3.7.0
-      strip-literal: 2.1.0
-      ufo: 1.5.4
-      unenv: 1.10.0
-      unplugin: 1.14.1(webpack-sources@3.2.3)
-      vite: 5.4.8(@types/node@18.19.57)(terser@5.17.6)
-      vite-node: 2.1.1(@types/node@18.19.57)(terser@5.17.6)
-      vite-plugin-checker: 0.8.0(eslint@9.12.0(jiti@2.3.3))(optionator@0.9.3)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue-tsc@2.1.6(typescript@5.6.3))
-      vue: 3.5.12(typescript@5.6.3)
-      vue-bundle-renderer: 2.1.0
-    transitivePeerDependencies:
-      - '@biomejs/biome'
-      - '@swc/core'
-      - '@types/node'
-      - eslint
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - optionator
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - typescript
-      - uWebSockets.js
-      - uglify-js
-      - vls
-      - vti
-      - vue-tsc
       - webpack-cli
       - webpack-sources
 
@@ -7859,7 +7563,7 @@ snapshots:
       - webpack-cli
       - webpack-sources
 
-  '@nuxt/vite-builder@3.13.2(@types/node@18.19.57)(eslint@9.12.0(jiti@2.3.3))(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.5)(terser@5.17.6)(typescript@5.6.3)(vue-tsc@2.1.6(typescript@5.6.3))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)':
+  '@nuxt/vite-builder@3.13.2(@types/node@18.19.57)(eslint@9.12.0(jiti@2.3.3))(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.5)(terser@5.17.6)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)':
     dependencies:
       '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)
       '@rollup/plugin-replace': 5.0.7(rollup@4.22.5)
@@ -7922,9 +7626,9 @@ snapshots:
       - webpack-cli
       - webpack-sources
 
-  '@nuxtjs/mdc@0.9.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)':
+  '@nuxtjs/mdc@0.9.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)':
     dependencies:
-      '@nuxt/kit': 3.13.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.13.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)
       '@shikijs/transformers': 1.22.0
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -8342,6 +8046,10 @@ snapshots:
 
   '@trysound/sax@0.2.0': {}
 
+  '@types/babel__generator@7.6.8':
+    dependencies:
+      '@babel/types': 7.25.9
+
   '@types/debug@4.1.8':
     dependencies:
       '@types/ms': 0.7.31
@@ -8575,19 +8283,19 @@ snapshots:
       - encoding
       - supports-color
 
-  '@vintl/unplugin@2.0.0(@vue/compiler-core@3.5.12)(rollup@3.29.4)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack@5.83.1)':
+  '@vintl/unplugin@2.0.0(@vue/compiler-core@3.5.12)(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack@5.83.1)':
     dependencies:
       '@formatjs/cli-lib': 6.3.3(@vue/compiler-core@3.5.12)(vue@3.5.12(typescript@5.6.3))
       '@formatjs/icu-messageformat-parser': 2.7.3
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.19.0)
       glob: 10.3.10
       import-meta-resolve: 4.1.0
       pathe: 1.1.2
       unplugin: 1.5.1
     optionalDependencies:
-      rollup: 3.29.4
+      rollup: 4.19.0
       vite: 5.4.8(@types/node@18.19.57)(terser@5.17.6)
-      webpack: 5.83.1
+      webpack: 5.83.1(esbuild@0.23.1)
     transitivePeerDependencies:
       - '@vue/compiler-core'
       - ts-jest
@@ -8636,22 +8344,9 @@ snapshots:
       '@eslint/config-array': 0.17.1
       '@nodelib/fs.walk': 2.0.0
 
-  '@vue-macros/common@1.14.0(rollup@3.29.4)(vue@3.5.12(typescript@5.6.3))':
-    dependencies:
-      '@babel/types': 7.25.6
-      '@rollup/pluginutils': 5.1.2(rollup@3.29.4)
-      '@vue/compiler-sfc': 3.5.11
-      ast-kit: 1.2.1
-      local-pkg: 0.5.0
-      magic-string-ast: 0.6.2
-    optionalDependencies:
-      vue: 3.5.12(typescript@5.6.3)
-    transitivePeerDependencies:
-      - rollup
-
   '@vue-macros/common@1.14.0(rollup@4.19.0)(vue@3.5.12(typescript@5.6.3))':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
       '@rollup/pluginutils': 5.1.2(rollup@4.19.0)
       '@vue/compiler-sfc': 3.5.11
       ast-kit: 1.2.1
@@ -8664,7 +8359,7 @@ snapshots:
 
   '@vue-macros/common@1.14.0(rollup@4.22.5)(vue@3.5.12(typescript@5.6.3))':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
       '@rollup/pluginutils': 5.1.2(rollup@4.22.5)
       '@vue/compiler-sfc': 3.5.11
       ast-kit: 1.2.1
@@ -8684,7 +8379,7 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.24.7)
       '@babel/template': 7.24.7
       '@babel/traverse': 7.24.7
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
       '@vue/babel-helper-vue-transform-on': 1.2.2
       '@vue/babel-plugin-resolve-type': 1.2.2(@babel/core@7.24.7)
       camelcase: 6.3.0
@@ -8858,13 +8553,13 @@ snapshots:
 
   '@vueuse/metadata@11.1.0': {}
 
-  '@vueuse/nuxt@11.1.0(esbuild@0.21.5)(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.19.0)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue-tsc@2.1.6(typescript@5.6.3))(webpack-sources@3.2.3))(rollup@4.19.0)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)':
+  '@vueuse/nuxt@11.1.0(esbuild@0.21.5)(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.5)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3))(rollup@4.22.5)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)':
     dependencies:
-      '@nuxt/kit': 3.13.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.13.2(esbuild@0.21.5)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)
       '@vueuse/core': 11.1.0(vue@3.5.12(typescript@5.6.3))
       '@vueuse/metadata': 11.1.0
       local-pkg: 0.5.0
-      nuxt: 3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.19.0)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue-tsc@2.1.6(typescript@5.6.3))(webpack-sources@3.2.3)
+      nuxt: 3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.5)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3)
       vue-demi: 0.14.10(vue@3.5.12(typescript@5.6.3))
     transitivePeerDependencies:
       - '@swc/core'
@@ -9075,8 +8770,6 @@ snapshots:
     dependencies:
       '@babel/parser': 7.25.6
       ast-kit: 1.2.1
-
-  astring@1.9.0: {}
 
   async-sema@3.1.1: {}
 
@@ -9769,7 +9462,7 @@ snapshots:
       minimatch: 9.0.5
       semver: 7.6.3
       stable-hash: 0.0.4
-      tslib: 2.6.3
+      tslib: 2.8.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10387,17 +10080,6 @@ snapshots:
 
   import-meta-resolve@4.1.0: {}
 
-  impound@0.1.0(rollup@3.29.4)(webpack-sources@3.2.3):
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
-      mlly: 1.7.1
-      pathe: 1.1.2
-      unenv: 1.10.0
-      unplugin: 1.14.1(webpack-sources@3.2.3)
-    transitivePeerDependencies:
-      - rollup
-      - webpack-sources
-
   impound@0.1.0(rollup@4.19.0)(webpack-sources@3.2.3):
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.19.0)
@@ -10440,7 +10122,7 @@ snapshots:
       '@formatjs/ecma402-abstract': 1.17.2
       '@formatjs/fast-memoize': 2.2.0
       '@formatjs/icu-messageformat-parser': 2.7.0
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   intl-messageformat@10.7.0:
     dependencies:
@@ -10589,8 +10271,6 @@ snapshots:
   jsdoc-type-pratt-parser@4.1.0: {}
 
   jsesc@0.5.0: {}
-
-  jsesc@2.5.2: {}
 
   jsesc@3.0.2: {}
 
@@ -10770,7 +10450,7 @@ snapshots:
 
   magic-string@0.30.10:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   magic-string@0.30.11:
     dependencies:
@@ -10779,7 +10459,7 @@ snapshots:
   magicast@0.3.5:
     dependencies:
       '@babel/parser': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
       source-map-js: 1.2.1
 
   make-dir@3.1.0:
@@ -11358,122 +11038,6 @@ snapshots:
 
   nuxi@3.14.0: {}
 
-  nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@3.29.4)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue-tsc@2.1.6(typescript@5.6.3))(webpack-sources@3.2.3):
-    dependencies:
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.5.1(esbuild@0.23.1)(rollup@3.29.4)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
-      '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)
-      '@nuxt/schema': 3.13.2(rollup@3.29.4)(webpack-sources@3.2.3)
-      '@nuxt/telemetry': 2.6.0(esbuild@0.23.1)(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)
-      '@nuxt/vite-builder': 3.13.2(@types/node@18.19.57)(eslint@9.12.0(jiti@2.3.3))(magicast@0.3.5)(optionator@0.9.3)(rollup@3.29.4)(terser@5.17.6)(typescript@5.6.3)(vue-tsc@2.1.6(typescript@5.6.3))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
-      '@unhead/dom': 1.11.7
-      '@unhead/shared': 1.11.7
-      '@unhead/ssr': 1.11.7
-      '@unhead/vue': 1.11.7(vue@3.5.12(typescript@5.6.3))
-      '@vue/shared': 3.5.10
-      acorn: 8.12.1
-      c12: 1.11.2(magicast@0.3.5)
-      chokidar: 3.6.0
-      compatx: 0.1.8
-      consola: 3.2.3
-      cookie-es: 1.2.2
-      defu: 6.1.4
-      destr: 2.0.3
-      devalue: 5.0.0
-      errx: 0.1.0
-      esbuild: 0.23.1
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      globby: 14.0.2
-      h3: 1.12.0
-      hookable: 5.5.3
-      ignore: 5.3.2
-      impound: 0.1.0(rollup@3.29.4)(webpack-sources@3.2.3)
-      jiti: 1.21.6
-      klona: 2.0.6
-      knitwork: 1.1.0
-      magic-string: 0.30.11
-      mlly: 1.7.1
-      nanotar: 0.1.1
-      nitropack: 2.9.7(encoding@0.1.13)(magicast@0.3.5)(webpack-sources@3.2.3)
-      nuxi: 3.14.0
-      nypm: 0.3.12
-      ofetch: 1.3.4
-      ohash: 1.1.4
-      pathe: 1.1.2
-      perfect-debounce: 1.0.0
-      pkg-types: 1.2.0
-      radix3: 1.1.2
-      scule: 1.3.0
-      semver: 7.6.3
-      std-env: 3.7.0
-      strip-literal: 2.1.0
-      tinyglobby: 0.2.6
-      ufo: 1.5.4
-      ultrahtml: 1.5.3
-      uncrypto: 0.1.3
-      unctx: 2.3.1(webpack-sources@3.2.3)
-      unenv: 1.10.0
-      unhead: 1.11.7
-      unimport: 3.13.1(rollup@3.29.4)(webpack-sources@3.2.3)
-      unplugin: 1.14.1(webpack-sources@3.2.3)
-      unplugin-vue-router: 0.10.8(rollup@3.29.4)(vue-router@4.4.5(vue@3.5.12(typescript@5.6.3)))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
-      unstorage: 1.12.0(ioredis@5.4.1)
-      untyped: 1.4.2
-      vue: 3.5.12(typescript@5.6.3)
-      vue-bundle-renderer: 2.1.0
-      vue-devtools-stub: 0.1.0
-      vue-router: 4.4.5(vue@3.5.12(typescript@5.6.3))
-    optionalDependencies:
-      '@parcel/watcher': 2.4.1
-      '@types/node': 18.19.57
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@swc/core'
-      - '@upstash/redis'
-      - '@vercel/kv'
-      - better-sqlite3
-      - bufferutil
-      - drizzle-orm
-      - encoding
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - optionator
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - typescript
-      - uWebSockets.js
-      - uglify-js
-      - utf-8-validate
-      - vite
-      - vls
-      - vti
-      - vue-tsc
-      - webpack-cli
-      - webpack-sources
-      - xml2js
-
   nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.19.0)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue-tsc@2.1.6(typescript@5.6.3))(webpack-sources@3.2.3):
     dependencies:
       '@nuxt/devalue': 2.0.2
@@ -11590,14 +11154,14 @@ snapshots:
       - webpack-sources
       - xml2js
 
-  nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.5)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue-tsc@2.1.6(typescript@5.6.3))(webpack-sources@3.2.3):
+  nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@18.19.57)(encoding@0.1.13)(eslint@9.12.0(jiti@2.3.3))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.5)(terser@5.17.6)(typescript@5.6.3)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(webpack-sources@3.2.3):
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/devtools': 1.5.1(esbuild@0.23.1)(rollup@4.22.5)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
       '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)
       '@nuxt/schema': 3.13.2(rollup@4.22.5)(webpack-sources@3.2.3)
       '@nuxt/telemetry': 2.6.0(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3)
-      '@nuxt/vite-builder': 3.13.2(@types/node@18.19.57)(eslint@9.12.0(jiti@2.3.3))(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.5)(terser@5.17.6)(typescript@5.6.3)(vue-tsc@2.1.6(typescript@5.6.3))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
+      '@nuxt/vite-builder': 3.13.2(@types/node@18.19.57)(eslint@9.12.0(jiti@2.3.3))(magicast@0.3.5)(optionator@0.9.3)(rollup@4.22.5)(terser@5.17.6)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3)
       '@unhead/dom': 1.11.7
       '@unhead/shared': 1.11.7
       '@unhead/ssr': 1.11.7
@@ -12322,15 +11886,6 @@ snapshots:
     optionalDependencies:
       '@babel/code-frame': 7.24.7
 
-  rollup-plugin-visualizer@5.12.0(rollup@3.29.4):
-    dependencies:
-      open: 8.4.2
-      picomatch: 2.3.1
-      source-map: 0.7.4
-      yargs: 17.7.2
-    optionalDependencies:
-      rollup: 3.29.4
-
   rollup-plugin-visualizer@5.12.0(rollup@4.19.0):
     dependencies:
       open: 8.4.2
@@ -12687,7 +12242,7 @@ snapshots:
   synckit@0.9.1:
     dependencies:
       '@pkgr/core': 0.1.1
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   system-architecture@0.1.0: {}
 
@@ -12721,7 +12276,7 @@ snapshots:
     optionalDependencies:
       esbuild: 0.21.5
 
-  terser-webpack-plugin@5.3.9(esbuild@0.23.1)(webpack@5.83.1(esbuild@0.23.1)):
+  terser-webpack-plugin@5.3.9(esbuild@0.23.1)(webpack@5.83.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -12731,15 +12286,6 @@ snapshots:
       webpack: 5.83.1(esbuild@0.23.1)
     optionalDependencies:
       esbuild: 0.23.1
-
-  terser-webpack-plugin@5.3.9(webpack@5.83.1):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      jest-worker: 27.5.1
-      schema-utils: 3.1.2
-      serialize-javascript: 6.0.1
-      terser: 5.17.6
-      webpack: 5.83.1
 
   terser@5.17.6:
     dependencies:
@@ -12773,8 +12319,6 @@ snapshots:
     dependencies:
       os-tmpdir: 1.0.2
 
-  to-fast-properties@2.0.0: {}
-
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -12796,8 +12340,6 @@ snapshots:
   tsconfck@3.1.3(typescript@5.6.3):
     optionalDependencies:
       typescript: 5.6.3
-
-  tslib@2.6.3: {}
 
   tslib@2.8.0: {}
 
@@ -12928,25 +12470,6 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.2
 
-  unimport@3.13.1(rollup@3.29.4)(webpack-sources@3.2.3):
-    dependencies:
-      '@rollup/pluginutils': 5.1.2(rollup@3.29.4)
-      acorn: 8.12.1
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      fast-glob: 3.3.2
-      local-pkg: 0.5.0
-      magic-string: 0.30.11
-      mlly: 1.7.2
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      scule: 1.3.0
-      strip-literal: 2.1.0
-      unplugin: 1.14.1(webpack-sources@3.2.3)
-    transitivePeerDependencies:
-      - rollup
-      - webpack-sources
-
   unimport@3.13.1(rollup@4.19.0)(webpack-sources@3.2.3):
     dependencies:
       '@rollup/pluginutils': 5.1.2(rollup@4.19.0)
@@ -13016,32 +12539,9 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unplugin-vue-router@0.10.8(rollup@3.29.4)(vue-router@4.4.5(vue@3.5.12(typescript@5.6.3)))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3):
-    dependencies:
-      '@babel/types': 7.25.6
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
-      '@vue-macros/common': 1.14.0(rollup@3.29.4)(vue@3.5.12(typescript@5.6.3))
-      ast-walker-scope: 0.6.2
-      chokidar: 3.6.0
-      fast-glob: 3.3.2
-      json5: 2.2.3
-      local-pkg: 0.5.0
-      magic-string: 0.30.11
-      mlly: 1.7.1
-      pathe: 1.1.2
-      scule: 1.3.0
-      unplugin: 1.14.1(webpack-sources@3.2.3)
-      yaml: 2.5.0
-    optionalDependencies:
-      vue-router: 4.4.5(vue@3.5.12(typescript@5.6.3))
-    transitivePeerDependencies:
-      - rollup
-      - vue
-      - webpack-sources
-
   unplugin-vue-router@0.10.8(rollup@4.19.0)(vue-router@4.4.5(vue@3.5.12(typescript@5.6.3)))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3):
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
       '@rollup/pluginutils': 5.1.0(rollup@4.19.0)
       '@vue-macros/common': 1.14.0(rollup@4.19.0)(vue@3.5.12(typescript@5.6.3))
       ast-walker-scope: 0.6.2
@@ -13064,7 +12564,7 @@ snapshots:
 
   unplugin-vue-router@0.10.8(rollup@4.22.5)(vue-router@4.4.5(vue@3.5.12(typescript@5.6.3)))(vue@3.5.12(typescript@5.6.3))(webpack-sources@3.2.3):
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.25.9
       '@rollup/pluginutils': 5.1.0(rollup@4.22.5)
       '@vue-macros/common': 1.14.0(rollup@4.22.5)(vue@3.5.12(typescript@5.6.3))
       ast-walker-scope: 0.6.2
@@ -13133,7 +12633,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/standalone': 7.23.10
-      '@babel/types': 7.25.0
+      '@babel/types': 7.25.9
       defu: 6.1.4
       jiti: 1.21.6
       mri: 1.2.0
@@ -13239,24 +12739,6 @@ snapshots:
       typescript: 5.6.3
       vue-tsc: 2.1.6(typescript@5.6.3)
 
-  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3))(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6)):
-    dependencies:
-      '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.2(rollup@4.19.0)
-      debug: 4.3.7
-      error-stack-parser-es: 0.1.5
-      fs-extra: 11.2.0
-      open: 10.1.0
-      perfect-debounce: 1.0.0
-      picocolors: 1.1.1
-      sirv: 2.0.4
-      vite: 5.4.8(@types/node@18.19.57)(terser@5.17.6)
-    optionalDependencies:
-      '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
   vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.22.5)(webpack-sources@3.2.3))(rollup@4.22.5)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6)):
     dependencies:
       '@antfu/utils': 0.7.10
@@ -13275,10 +12757,10 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3))(rollup@3.29.4)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6)):
+  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3))(rollup@4.19.0)(vite@5.4.8(@types/node@18.19.57)(terser@5.17.6)):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.2(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.2(rollup@4.19.0)
       debug: 4.3.7
       error-stack-parser-es: 0.1.5
       fs-extra: 11.2.0
@@ -13288,7 +12770,7 @@ snapshots:
       sirv: 2.0.4
       vite: 5.4.8(@types/node@18.19.57)(terser@5.17.6)
     optionalDependencies:
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.13.2(esbuild@0.23.1)(magicast@0.3.5)(rollup@4.19.0)(webpack-sources@3.2.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -13416,37 +12898,6 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.83.1:
-    dependencies:
-      '@types/eslint-scope': 3.7.4
-      '@types/estree': 1.0.6
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.12.1
-      acorn-import-assertions: 1.9.0(acorn@8.12.1)
-      browserslist: 4.23.2
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.5.4
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.1.2
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(webpack@5.83.1)
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
   webpack@5.83.1(esbuild@0.21.5):
     dependencies:
       '@types/eslint-scope': 3.7.4
@@ -13501,7 +12952,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.1.2
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(esbuild@0.23.1)(webpack@5.83.1(esbuild@0.23.1))
+      terser-webpack-plugin: 5.3.9(esbuild@0.23.1)(webpack@5.83.1)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
Previously runtime options were generated using manually created AST
nodes and `astring` module. This was hindersome to maintain, so I
decided to switch to using recast at first, but quickly found it doesn't
support some of AST types that we need, so I've migrated to Babel
modules instead, which provide all the nice APIs and generate more
correct code than recast.
